### PR TITLE
Add scheduled functions support

### DIFF
--- a/src/CloudFunctions.Types.fs
+++ b/src/CloudFunctions.Types.fs
@@ -1,0 +1,13 @@
+namespace Fable.FirebaseFunctions.CloudFunctions
+
+type [<AllowNullLiteral>] ScheduleRetryConfig =
+    abstract retryCount: float option with get, set
+    abstract maxRetryDuration: string option with get, set
+    abstract minBackoffDuration: string option with get, set
+    abstract maxBackoffDuration: string option with get, set
+    abstract maxDoublings: float option with get, set
+
+type [<AllowNullLiteral>] Schedule =
+    abstract schedule: string with get, set
+    abstract timeZone: string option with get, set
+    abstract retryConfig: ScheduleRetryConfig option with get, set

--- a/src/CloudFunctions.fs
+++ b/src/CloudFunctions.fs
@@ -17,15 +17,15 @@ type [<AllowNullLiteral>] IExports =
 /// - The resource on which the event occurred, if applicable.
 /// - Authorization of the request that triggered the event, if applicable and available.
 type [<AllowNullLiteral>] EventContext =
-    /// ID of the event 
+    /// ID of the event
     abstract eventId: string with get, set
-    /// Timestamp for when the event occured (ISO string) 
+    /// Timestamp for when the event occured (ISO string)
     abstract timestamp: string with get, set
-    /// Type of event 
+    /// Type of event
     abstract eventType: string with get, set
-    /// Resource that triggered the event 
+    /// Resource that triggered the event
     abstract resource: Resource with get, set
-    /// Key-value pairs that represent the values of wildcards in a database reference 
+    /// Key-value pairs that represent the values of wildcards in a database reference
     abstract ``params``: TypeLiteral_01 with get, set
     /// Type of authentication for the triggering action, valid value are: 'ADMIN', 'USER',
     /// 'UNAUTHENTICATED'. Only available for database functions.
@@ -46,20 +46,20 @@ type [<AllowNullLiteral>] Change<'T> =
 type [<AllowNullLiteral>] ChangeStatic =
     [<Emit "new $0($1...)">] abstract Create: ?before: 'T * ?after: 'T -> Change<'T>
 
-/// ChangeJson is the JSON format used to construct a Change object. 
+/// ChangeJson is the JSON format used to construct a Change object.
 type [<AllowNullLiteral>] ChangeJson =
     /// Key-value pairs representing state of data before the change.
     /// If `fieldMask` is set, then only fields that changed are present in `before`.
     abstract before: obj option with get, set
-    /// Key-value pairs representing state of data after the change. 
+    /// Key-value pairs representing state of data after the change.
     abstract after: obj option with get, set
-    /// Comma-separated string that represents names of field that changed. 
+    /// Comma-separated string that represents names of field that changed.
     abstract fieldMask: string option with get, set
 
 module Change =
 
     type [<AllowNullLiteral>] IExports =
-        /// Factory method for creating a Change from a `before` object and an `after` object. 
+        /// Factory method for creating a Change from a `before` object and an `after` object.
         abstract fromObjects: before: 'T * after: 'T -> Change<'T>
         /// Factory method for creating a Change from a JSON and an optional customizer function to be
         /// applied to both the `before` and the `after` fields.
@@ -73,11 +73,11 @@ type [<AllowNullLiteral>] Resource =
     abstract ``type``: string option with get, set
     abstract labels: TypeLiteral_03 option with get, set
 
-/// TriggerAnnotated is used internally by the firebase CLI to understand what type of Cloud Function to deploy. 
+/// TriggerAnnotated is used internally by the firebase CLI to understand what type of Cloud Function to deploy.
 type [<AllowNullLiteral>] TriggerAnnotated =
     abstract __trigger: TypeLiteral_07 with get, set
 
-/// A Runnable has a `run` method which directly invokes the user-defined function - useful for unit testing. 
+/// A Runnable has a `run` method which directly invokes the user-defined function - useful for unit testing.
 type [<AllowNullLiteral>] Runnable<'T> =
     abstract run: ('T -> obj option -> U2<PromiseLike<obj option>, obj option>) with get, set
 

--- a/src/Fable.FirebaseFunctions.fsproj
+++ b/src/Fable.FirebaseFunctions.fsproj
@@ -14,6 +14,7 @@
         <PackageTags>F#, fsharp, fable2, fable-bindings, firebase, firebase-admin, firebase-functions</PackageTags>
     </PropertyGroup>
     <ItemGroup>
+        <Compile Include="CloudFunctions.Types.fs" />
         <Compile Include="FirebaseFunctions.Types.fs" />
         <Compile Include="Utils.fs" />
         <Compile Include="CloudFunctions.fs" />

--- a/src/FirebaseFunctions.Types.fs
+++ b/src/FirebaseFunctions.Types.fs
@@ -9,3 +9,4 @@ type [<AllowNullLiteral>] DeploymentOptions =
     abstract regions: ResizeArray<string> option with get, set
     abstract timeoutSeconds: float option with get, set
     abstract memory: string option with get, set
+    abstract schedule : CloudFunctions.Schedule option with get, set

--- a/src/Providers/Pubsub.fs
+++ b/src/Providers/Pubsub.fs
@@ -8,21 +8,31 @@ open Fable.FirebaseFunctions
 type [<AllowNullLiteral>] IExports =
     /// <summary>Select Cloud Pub/Sub topic to listen to.</summary>
     /// <param name="topic">Name of Pub/Sub topic, must belong to the same project as the function.</param>
-    abstract topic: topic: string -> TopicBuilder
+    abstract schedule: schedule: string -> ScheduleBuilder
+    abstract ScheduleBuilder: ScheduleBuilderStatic
+    abstract topic: topic: string -> unit
     abstract TopicBuilder: TopicBuilderStatic
     abstract Message: MessageStatic
 
-/// Builder used to create Cloud Functions for Google Pub/Sub topics. 
+type [<AllowNullLiteral>] ScheduleBuilder =
+    abstract retryConfig: config: CloudFunctions.ScheduleRetryConfig -> ScheduleBuilder
+    abstract timeZone: timeZone: string -> ScheduleBuilder
+    abstract onRun: handler: (CloudFunctions.EventContext -> U2<PromiseLike<obj option>, obj option>) -> unit
+
+type [<AllowNullLiteral>] ScheduleBuilderStatic =
+    [<Emit "new $0($1...)">] abstract Create: schedule: CloudFunctions.Schedule * opts: DeploymentOptions -> ScheduleBuilder
+
+/// Builder used to create Cloud Functions for Google Pub/Sub topics.
 type [<AllowNullLiteral>] TopicBuilder =
-    /// Handle a Pub/Sub message that was published to a Cloud Pub/Sub topic 
+    /// Handle a Pub/Sub message that was published to a Cloud Pub/Sub topic
     abstract onPublish: handler: (Message -> CloudFunctions.EventContext -> U2<PromiseLike<obj option>, obj option>) -> CloudFunctions.CloudFunction<Message>
 
-/// Builder used to create Cloud Functions for Google Pub/Sub topics. 
+/// Builder used to create Cloud Functions for Google Pub/Sub topics.
 type [<AllowNullLiteral>] TopicBuilderStatic =
-    [<Emit "new $0($1...)">] abstract Create: unit -> TopicBuilder
+    [<Emit "new $0($1...)">] abstract Create: triggerResource: (unit -> string) * opts: DeploymentOptions -> TopicBuilder
 
 /// A Pub/Sub message.
-/// 
+///
 /// This class has an additional .json helper which will correctly deserialize any
 /// message that was a JSON object when published with the JS SDK. .json will throw
 /// if the message is not a base64 encoded JSON string.
@@ -33,7 +43,7 @@ type [<AllowNullLiteral>] Message =
     abstract toJSON: unit -> obj option
 
 /// A Pub/Sub message.
-/// 
+///
 /// This class has an additional .json helper which will correctly deserialize any
 /// message that was a JSON object when published with the JS SDK. .json will throw
 /// if the message is not a base64 encoded JSON string.


### PR DESCRIPTION
Implements bindings that allow for functions to be triggered on a schedule.

Details here: https://firebase.googleblog.com/2019/04/schedule-cloud-functions-firebase-cron.html